### PR TITLE
fix some paths

### DIFF
--- a/packages/Offline/package.py
+++ b/packages/Offline/package.py
@@ -67,11 +67,11 @@ class Offline(CMakePackage):
         env.prepend_path("CET_PLUGIN_PATH", prefix.lib)
         # Ensure we can find fhicl files
         env.prepend_path("FHICL_FILE_PATH", prefix + "/fcl")
+        env.prepend_path("MU2E_SEARCH_PATH", "/cvmfs/mu2e.opensciencegrid.org/DataFiles")
         env.prepend_path("MU2E_SEARCH_PATH", prefix + "/fcl")
-        # Ensure we can find data files
-        env.prepend_path("MU2E_DATA_PATH", prefix + "/share")
+        env.prepend_path("MU2E_SEARCH_PATH", prefix + "/share")
         # Cleaup.
-        sanitize_environments(env, "CET_PLUGIN_PATH", "FHICL_FILE_PATH", "MU2E_SEARCH_PATH", "MU2E_DATA_PATH")
+        sanitize_environments(env, "CET_PLUGIN_PATH", "FHICL_FILE_PATH", "MU2E_SEARCH_PATH")
 
     def setup_dependent_run_environment(self, env, dependent_spec):
         prefix = self.prefix


### PR DESCRIPTION
- MU2E_SEARCH_PATH includes share (Offline/*/data) and /cvmfs/mu2e.opensciencegrid.org/DataFiles
- MU2E_DATA_PATH removed (not used in Offline)
- MU2E_SEARCH_PATH should not include fcl but still a problem with, at least 
`Offline/CRVResponse/fcl/singlePEWaveform_v3.txt`
which should be moved out of fcl and any fcl references updated.  Not sure if there are more issues.  
