### PR TITLE
Update 250207

### DIFF
--- a/packages/Offline/package.py
+++ b/packages/Offline/package.py
@@ -51,7 +51,7 @@ class Offline(CMakePackage):
     depends_on("kinkal@3.1.3", when="@11.03.00")
     depends_on("kinkal@3.1.4", when="@11.04.00")
     depends_on("kinkal@3.1.4", when="@develop") # UPDATE AS NEEDED
-    depends_on("kinkal@3.1.4", when="@main") # UPDATE AS NEEDED
+    depends_on("kinkal@3.1.4,main", when="@main") # UPDATE AS NEEDED
 
     depends_on("btrk")
     depends_on("gallery")

--- a/packages/kinkal/package.py
+++ b/packages/kinkal/package.py
@@ -62,15 +62,22 @@ class Kinkal(CMakePackage):
 
     @run_before('build')
     def makelink(self):
-        with working_dir(self.stage.path):
-            if os.path.isdir("spack-src") :
-                tdir = '%s/spack-src' % self.stage.path
-                linkname = '%s/KinKal' % self.stage.path
-            else :
-                tdir = self.stage.path
-                linkname = '%s/../KinKal' % self.stage.path
-            if not os.path.islink(linkname) :
-                os.symlink(tdir, linkname)
+        # at some point the stage.path changed from the
+        # repo dir to /tmp
+        wdir = self.stage.path
+        if wdir[:4] == "/tmp" :
+            tdir = self.stage.source_path
+            linkname = '%s/../KinKal' % self.stage.source_path
+        else :
+            with working_dir(self.stage.path):
+                if os.path.isdir("spack-src") :
+                    tdir = '%s/spack-src' % self.stage.path
+                    linkname = '%s/KinKal' % self.stage.path
+                else :
+                    tdir = self.stage.path
+                    linkname = '%s/../KinKal' % self.stage.path
+        if not os.path.islink(linkname) :
+            os.symlink(tdir, linkname)
 
     @run_after('install')
     def copy_headers(self):


### PR DESCRIPTION
- later versions of spack change where the ad-hoc link for the include files has to go for kinkal in development mode
- allow Offline and kinkal to both be in development mode
These should be backwards compatible