### PR TITLE
Updating package version

### DIFF
--- a/packages/Offline/package.py
+++ b/packages/Offline/package.py
@@ -23,6 +23,8 @@ class Offline(CMakePackage):
 
     version("main", branch="main", get_full_repo=True)
     version("develop", branch="main", get_full_repo=True) # spack-mpd expects develop version
+
+    version("11.05.01", commit="da34cccbf365f0b85194e0ce10108ddfb286d38a")
     version("11.04.00", commit="86ef8c73e1683532cec252bbfe6fa64815a9d4d3")
     version("11.03.00", commit="57339a5a43a073c9657f221b1d96d5a7b3c48b4b")
     version("11.02.00", commit="83ca01342f4ad86c4452babbb8a7083412dcfa88")

--- a/packages/artdaq-core-mu2e/package.py
+++ b/packages/artdaq-core-mu2e/package.py
@@ -33,6 +33,7 @@ class ArtdaqCoreMu2e(CMakePackage):
 
     version("develop", branch="develop", get_full_repo=True)
 
+    version("v3_04_00", commit="e023e3e79970a74628aba3cf6b122c50e1fea1de")
     version("v3_03_01", commit="c426d9775165539da76f6a813c007371460652c3")
     version("v3_03_00", commit="27aa987c0a7994c5d558d97c6fb00a3119b259ad")
     version("v3_02_00", commit="f0814116e7aaacbd69c5884fe56c8bbdf2b2d4da")

--- a/packages/artdaq-mu2e/package.py
+++ b/packages/artdaq-mu2e/package.py
@@ -32,6 +32,7 @@ class ArtdaqMu2e(CMakePackage):
 
     version("develop", branch="develop", get_full_repo=True)
 
+    version("v3_04_00", commit="83a9e195a7a9e992cf2b12e5a022f5cc59bb81fb")
     version("v3_03_01", commit="ea21383a8e95b2cda4a72c9cfb53f5d94b98963d")
     version("v3_03_00", commit="fc6b9c26023d3cb9ca43a501f2adcea0396e559f")
     version("v3_02_00", commit="f85274201adcf7008393bf36b0613f41498662f5")

--- a/packages/mu2e-pcie-utils/package.py
+++ b/packages/mu2e-pcie-utils/package.py
@@ -28,6 +28,7 @@ class Mu2ePcieUtils(CMakePackage):
     version("ryan_test", commit="112bf71f774d02dbee316232c82250beb4306885")
     version("develop", branch="develop", get_full_repo=True)
 
+    version("v3_04_00", commit="b9e229970b1075990aa0ed007fa399583cc1c260")
     version("v3_03_01", commit="e2bf8f658055f43cd1a790456daf7c3495fb7061")
     version("v3_03_00", commit="bcbe4bdbc86e7d854f94abb813cb64da666d878d")
     version("v3_02_00", commit="2fc701067582ef63fdcc8ddfbf1437e5209fe2ea")

--- a/packages/mu2e-tdaq-suite/package.py
+++ b/packages/mu2e-tdaq-suite/package.py
@@ -12,6 +12,7 @@ class Mu2eTdaqSuite(BundlePackage):
     """The Mu2e TDAQ Suite, the software used for Mu2e trigger and data acquisition"""
 
     version("develop")
+    version("v3_04_00")
     version("v3_03_01")
     version("v3_03_00")
     version("v3_02_00")
@@ -80,6 +81,21 @@ class Mu2eTdaqSuite(BundlePackage):
     )
 
     # Bundle package, list packages that are part of the bundle
+    with when("@v3_04_00"): 
+        depends_on("artdaq-core-mu2e@v3_04_00")
+        depends_on("mu2e-pcie-utils@v3_04_00")
+        depends_on("artdaq-mu2e@v3_04_00")
+        depends_on("otsdaq-mu2e@v3_04_00")
+        depends_on("otsdaq-mu2e-calorimeter@v3_04_00")
+        depends_on("otsdaq-mu2e-crv@v3_04_00")
+        depends_on("otsdaq-mu2e-extmon@v3_04_00")
+        depends_on("otsdaq-mu2e-stm@v3_04_00")
+        depends_on("Offline@11.05.01~g4", when="~g4")
+        depends_on("Offline@11.05.01+g4", when="+g4")
+        depends_on("otsdaq-mu2e-tracker@v3_04_00")
+        depends_on("otsdaq-mu2e-dqm@v3_04_00")
+        depends_on("otsdaq-mu2e-trigger@v3_04_00")
+        depends_on("mu2e-trig-config@v3_07_00") 
     with when("@v3_03_01"):
         depends_on("artdaq-core-mu2e@v3_03_01")
         depends_on("mu2e-pcie-utils@v3_03_01")

--- a/packages/mu2e-trig-config/package.py
+++ b/packages/mu2e-trig-config/package.py
@@ -27,9 +27,9 @@ class Mu2eTrigConfig(CMakePackage):
     license("Apache-2.0")
 
     version("main", branch="main", get_full_repo=True)
-    version(
-        "develop", branch="main", get_full_repo=True
-    )  # spack-mpd expects develop version
+    version("develop", branch="main", get_full_repo=True)  # spack-mpd expects develop version
+    
+    version("v3_07_00", commit="a2428b1cf5be5d0c27414305c0047bc5865abdd1")
     version("v3_05_00", commit="fa2bba9d587c20a4506fd119634122a8990c11e4")
     version("v3_03_01", commit="e2c8b4dc4f21ccd759d2ac1c21522e0ac54b1b75")
     version("v3_03_00", commit="81759c02641607a4792235bca47c156f1e5b1d64")

--- a/packages/otsdaq-mu2e-calorimeter/package.py
+++ b/packages/otsdaq-mu2e-calorimeter/package.py
@@ -23,6 +23,8 @@ class OtsdaqMu2eCalorimeter(CMakePackage):
     license("BSD")
 
     version("develop", branch="develop", get_full_repo=True)
+
+    version("v3_04_00", commit="1e89384ec6ee16c2ae6a099f47b68b932a028be2")
     version("v3_03_01", commit="b6f82e51e84a99870a2cf16ea65ee3fec3784215")
     version("v3_03_00", commit="2abf5f4f2e88fed5b8f68a4c65b6916809a07a31")
     version("v3_02_00", commit="28d8a50d574ad4dc6b7638dd2f8a47b0c74b940d")

--- a/packages/otsdaq-mu2e-crv/package.py
+++ b/packages/otsdaq-mu2e-crv/package.py
@@ -24,6 +24,8 @@ class OtsdaqMu2eCrv(CMakePackage):
     license("BSD")
 
     version("develop", branch="develop", get_full_repo=True)
+
+    version("v3_04_00", commit="09d8ad6194ebb463721b019f83a947db018ba2fc")
     version("v3_03_01", commit="88d2661aa164ff54740765a327ae976ce964c72a")
     version("v3_03_00", commit="f7e1a8ef3f8710f5db961ec62ef78a28c50114f2")
     version("v3_02_00", commit="13b95db97eed103a563aa25631a8d86c536a88b1")

--- a/packages/otsdaq-mu2e-dqm/package.py
+++ b/packages/otsdaq-mu2e-dqm/package.py
@@ -24,6 +24,8 @@ class OtsdaqMu2eDqm(CMakePackage):
     license("BSD")
 
     version("develop", branch="develop", get_full_repo=True)
+
+    version("v3_04_00", commit="181dcf40b42f0b4ad9cd2d4510347bbd45cf28de")
     version("v3_03_01", commit="8711d0c2cf455a86d7675997d57fcdf76c49ac4e")
     version("v3_03_00", commit="9aa1075a2df5c0fbcfd0bd44723be55ebcf81453")
     version("v3_02_00", commit="c2f4fd5f94cadf8cee755f112dac74a41c1d2612")

--- a/packages/otsdaq-mu2e-extmon/package.py
+++ b/packages/otsdaq-mu2e-extmon/package.py
@@ -24,6 +24,8 @@ class OtsdaqMu2eExtmon(CMakePackage):
     license("BSD")
 
     version("develop", branch="develop", get_full_repo=True)
+
+    version("v3_04_00", commit="45487ff03d26db846b7bfd75f012bd08550ce777")
     version("v3_03_01", commit="28a6db8f67326889ccf1a48173d0cd7d96b99bb3")
     version("v3_03_00", commit="fc794c683bdc4d352d595995555796d30f0c6a21")
     version("v3_02_00", commit="9e9127ad8d66048095b79af6359f9d5f1f66b2d3")

--- a/packages/otsdaq-mu2e-stm/package.py
+++ b/packages/otsdaq-mu2e-stm/package.py
@@ -24,6 +24,8 @@ class OtsdaqMu2eStm(CMakePackage):
     license("BSD")
 
     version("develop", branch="develop", get_full_repo=True)
+
+    version("v3_04_00", commit="66abac00f6827c01c84922ed7439949696f72b1b")
     version("v3_03_01", commit="e3a40202b5f53457d3295a6b45d0ae4d3b6de10f")
     version("v3_03_00", commit="bae653f1dba66bed5e34d0572cc64bdd2964e344")
     version("v3_02_00", commit="60f66352d3446926eb74ff4f3b51b3b915a8f343")

--- a/packages/otsdaq-mu2e-tracker/package.py
+++ b/packages/otsdaq-mu2e-tracker/package.py
@@ -24,6 +24,8 @@ class OtsdaqMu2eTracker(CMakePackage):
     license("BSD")
 
     version("develop", branch="develop", get_full_repo=True)
+    
+    version("v3_04_00", commit="15e98583e9f0c4dab6f2b6d26ced5bf46de8b049")
     version("v3_03_01", commit="22cd17fe4aa21f82ee0f42682992a3c3c2e2dbf1")
     version("v3_03_00", commit="0911662b152a239faff831625985e8c30b6c8357")
     version("v3_02_00", commit="aca901c7655eee59bab3ca6b42ed354e8d7f7bac")

--- a/packages/otsdaq-mu2e-trigger/package.py
+++ b/packages/otsdaq-mu2e-trigger/package.py
@@ -23,6 +23,8 @@ class OtsdaqMu2eTrigger(CMakePackage):
     license("BSD")
 
     version("develop", branch="develop", get_full_repo=True)
+
+    version("v3_04_00", commit="5665ade59ed50e468e3096b86d2315ffc05cf48e")
     version("v3_03_01", commit="abe44d23ec6f7ae1d1d2b078e96483a81d38682c")
     version("v3_03_00", commit="e5a81b80574a3f9f42f7db289ddea715279cbdd5")
     version("v3_02_00", commit="c9454dd65511de02331f0e822e34c68e2665b7ff")

--- a/packages/otsdaq-mu2e/package.py
+++ b/packages/otsdaq-mu2e/package.py
@@ -33,6 +33,8 @@ class OtsdaqMu2e(CMakePackage):
     license("BSD")
 
     version("develop", branch="develop", get_full_repo=True)
+
+    version("v3_04_00", commit="7f1e42edb3bc1590e6ea5add941aafdaf9222bc2")
     version("v3_03_01", commit="50a13f6747f4e03579c6152440d597b203e96ea0")
     version("v3_03_00", commit="29f817d994f86ebab7868b77c89da7ed700513f9")
     version("v3_02_00", commit="d4fe57c28582a28712f8560d4384654796350068")


### PR DESCRIPTION
In the past we have aligned the version of each individual package with the version of the tdaq-suite. Starting now we are no longer following this convention. 