### PR TITLE
otsdaq-mu2e-crv: adding 'root+webgui' dependency

### DIFF
--- a/packages/otsdaq-mu2e-crv/package.py
+++ b/packages/otsdaq-mu2e-crv/package.py
@@ -47,6 +47,7 @@ class OtsdaqMu2eCrv(CMakePackage):
 
     depends_on("otsdaq-mu2e")
     depends_on("cetmodules", type="build")
+    depends_on("root+webgui")
 
     def cmake_args(self):
         args = [


### PR DESCRIPTION
This is/was intended to be part of v3_04_00. I believe this is needed for tdaq suite v3_04_00 to fully compile. 