### PR TITLE
default to RelWithDebInfo

### DIFF
--- a/packages/Offline/package.py
+++ b/packages/Offline/package.py
@@ -49,6 +49,9 @@ class Offline(CMakePackage):
         description="Use the specified C++ standard when building.",
     )
 
+    variant("build_type", default="RelWithDebInfo",
+            description="CMake build type")
+
     # Direct dependencies, see ups/product_deps
     depends_on("geant4", when="+g4")
     depends_on("cetmodules@3.26.00:", type="build")

--- a/packages/artdaq-core-mu2e/package.py
+++ b/packages/artdaq-core-mu2e/package.py
@@ -64,6 +64,9 @@ class ArtdaqCoreMu2e(CMakePackage):
         description="Use the specified C++ standard when building.",
     )
 
+    variant("build_type", default="RelWithDebInfo",
+            description="CMake build type")
+
     depends_on("cetmodules@3.26.00:", type="build")
 
     depends_on("mu2e-pcie-utils@:v2_09_00", when="@:v1_09_02")


### PR DESCRIPTION
Without this, spack will default to Release, but our standard as always been RelWithDebInfo. With this in place, we can remove build_type specifications, which will make it easier to switch to Debug on demand.