### PR TITLE
make a spack build banner

### DIFF
--- a/packages/Offline/package.py
+++ b/packages/Offline/package.py
@@ -95,6 +95,10 @@ class Offline(CMakePackage):
         env.prepend_path("MU2E_SEARCH_PATH", "/cvmfs/mu2e.opensciencegrid.org/DataFiles")
         env.prepend_path("MU2E_SEARCH_PATH", prefix + "/fcl")
         env.prepend_path("MU2E_SEARCH_PATH", prefix + "/share")
+        # show summary of configuration at start of mu2e exe
+        pkgs = ["art", "root", "kinkal", "artdaq-core-mu2e"]
+        banner = " ".join(f"{pkg}@{self.spec[pkg].version}" for pkg in pkgs)
+        env.set("OFFLINE_BANNER",banner)
         # Cleaup.
         sanitize_environments(env, "CET_PLUGIN_PATH", "FHICL_FILE_PATH", "MU2E_SEARCH_PATH")
 


### PR DESCRIPTION
Muse has a banner print at the start of the mu2e exe, but in a spack build the banner is broken  This addition will drive a spack-ready banner print like:
```
   ************************** Mu2e Offline **************************
     art@3.15.00 root@6.32.06 kinkal@3.2.1 artdaq-core-mu2e@v8_01_00
   ******************************************************************

```