### PR TITLE
Fix missing permissions in all GitHub Actions workflows

### DIFF
--- a/.github/workflows/git-whitespace.yml
+++ b/.github/workflows/git-whitespace.yml
@@ -14,6 +14,9 @@ on:
     - cron: "0 7 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   check_whitespace_dispatch:
     name: Check Git whitespace

--- a/.github/workflows/mu2e-format-single-pkg.yml
+++ b/.github/workflows/mu2e-format-single-pkg.yml
@@ -14,6 +14,9 @@ on:
     - cron: "0 7 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
 
   build_single_pkg:

--- a/.github/workflows/track_new_issues.yml
+++ b/.github/workflows/track_new_issues.yml
@@ -4,6 +4,9 @@ on:
     types:
       - opened
 
+permissions:
+  contents: read
+
 jobs:
   track_issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/track_new_prs.yml
+++ b/.github/workflows/track_new_prs.yml
@@ -3,6 +3,10 @@ on:
   pull_request:
     types:
       - opened
+
+permissions:
+  contents: read
+
 jobs:
   track_issue:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes <a href="https://github.com/Mu2e/mu2e-spack/security/code-scanning/7">https://github.com/Mu2e/mu2e-spack/security/code-scanning/7</a> and extends the fix to all workflows in the repository.

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults unless overridden. The safest minimal non-breaking baseline is:

- `contents: read`

This documents intended access and avoids inheriting broader defaults.

Changes applied to all four workflows in `.github/workflows/`:

- `mu2e-format-single-pkg.yml`
- `git-whitespace.yml`
- `track_new_issues.yml`
- `track_new_prs.yml`

No imports, methods, or dependencies are required (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._